### PR TITLE
add DBSEdge specialization for DB-Svc edges

### DIFF
--- a/collector/src/core/entities/dbs_edge.ts
+++ b/collector/src/core/entities/dbs_edge.ts
@@ -1,0 +1,17 @@
+import { Database } from './database';
+import { Edge } from './edge';
+import { Service } from './service';
+
+export class DBSEdge extends Edge {
+  constructor(private readonly db: Database, private readonly svc: Service, public readonly payload: any = null) {
+    super(db, svc, payload);
+  }
+
+  get service(): Service {
+    return this.svc;
+  }
+
+  get database(): Database {
+    return this.db;
+  }
+}

--- a/collector/src/core/entities/edge.ts
+++ b/collector/src/core/entities/edge.ts
@@ -1,6 +1,6 @@
 import { Vertex } from './vertex';
 
-export class Edge {
+export abstract class Edge {
   private static nextID = 0;
   private _id: number;
 

--- a/collector/src/index.ts
+++ b/collector/src/index.ts
@@ -4,8 +4,8 @@ import { RepositoriesController } from './framework/controllers/repositories_con
 
 import { Service } from './core/entities/service';
 import { Database } from './core/entities/database';
-import { Edge } from './core/entities/edge';
 import { Graph } from './core/entities/graph';
+import { DBSEdge } from './core/entities/dbs_edge';
 
 const port = process.env.PORT || 3000;
 
@@ -21,7 +21,7 @@ app.listen(port, () => {
   const svc = new Service('foo');
   const db = new Database('MongoDB', 'document');
 
-  const e = new Edge(svc, db, { namespace: 'foo' });
+  const e = new DBSEdge(db, svc, { namespace: 'foo' });
 
   const g = new Graph();
 


### PR DESCRIPTION
O intuito dessa especialização de `Edge` é ter um tratamento mais claro para a visitação do grafo, em particular para a visitação de identificação de uso de banco de dados.

Signed-off-by: João Daniel <jotaf.daniel@gmail.com>